### PR TITLE
feat: add $orderby support to query-records tool

### DIFF
--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -23,11 +23,14 @@ export class RecordService {
    * @param entityNamePlural The plural name of the entity (e.g., 'accounts', 'contacts')
    * @param filter OData filter expression (e.g., "name eq 'test'")
    * @param maxRecords Maximum number of records to retrieve (default: 50)
+   * @param orderby OData orderby expression (e.g., "createdon desc" or "name asc")
    * @returns Filtered list of records
    */
-  async queryRecords(entityNamePlural: string, filter: string, maxRecords: number = 50): Promise<ApiCollectionResponse<any>> {
-    return this.client.get<ApiCollectionResponse<any>>(
-      `api/data/v9.2/${entityNamePlural}?$filter=${encodeURIComponent(filter)}&$top=${maxRecords}`
-    );
+  async queryRecords(entityNamePlural: string, filter: string, maxRecords: number = 50, orderby?: string): Promise<ApiCollectionResponse<any>> {
+    let url = `api/data/v9.2/${entityNamePlural}?$filter=${encodeURIComponent(filter)}&$top=${maxRecords}`;
+    if (orderby) {
+      url += `&$orderby=${encodeURIComponent(orderby)}`;
+    }
+    return this.client.get<ApiCollectionResponse<any>>(url);
   }
 }

--- a/src/tools/recordTools.ts
+++ b/src/tools/recordTools.ts
@@ -60,6 +60,7 @@ export function registerRecordTools(server: McpServer, ctx: ServiceContext): voi
         entityNamePlural: z.string().describe("The plural name of the entity (e.g., 'accounts', 'contacts')"),
         filter: z.string().describe("OData filter expression (e.g., \"name eq 'test'\" or \"createdon gt 2023-01-01\")"),
         maxRecords: z.number().optional().describe("Maximum number of records to retrieve (default: 50)"),
+        orderby: z.string().optional().describe("OData orderby expression (e.g., \"createdon desc\" or \"name asc\")"),
       },
       outputSchema: z.object({
         entityNamePlural: z.string(),
@@ -68,10 +69,10 @@ export function registerRecordTools(server: McpServer, ctx: ServiceContext): voi
         records: z.any(),
       }),
     },
-    async ({ entityNamePlural, filter, maxRecords }) => {
+    async ({ entityNamePlural, filter, maxRecords, orderby }) => {
       try {
         const service = ctx.getRecordService();
-        const records = await service.queryRecords(entityNamePlural, filter, maxRecords || 50);
+        const records = await service.queryRecords(entityNamePlural, filter, maxRecords || 50, orderby);
         const recordCount = records.value?.length || 0;
 
         return {


### PR DESCRIPTION
## Summary
Adds `$orderby` support to the `query-records` tool, allowing users to sort query results.

## Changes
- Added optional `orderby` parameter to query-records tool schema
- Updated RecordService.queryRecords to accept and apply orderby parameter
- Query URL now includes `$orderby={value}` when parameter is provided

## Example
```
api/data/v9.2/accounts?$filter=name eq 'test'&$orderby=createdon desc&$top=50
```

Fixes #1

Generated with [Claude Code](https://claude.ai/code)